### PR TITLE
[B] fecth first root domain

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -11,7 +11,7 @@
   },
   "crawler": {
     "entryDomain": "www.onefootball.com",
-    "entryPath": "/en",
+    "entryPath": "/",
     "queue": "/arena/solifugae_data/queue.json",
     "entryProtocol": "https",
     "prefixFolder": "pub",


### PR DESCRIPTION
This is a temporary bugfix. If we start with folder, every time process is restarted it will write our starting URL in the sitemap. We do not want that. If we start with root domain, that will not happen. 
This can be more properly fixed by updating the queue. 